### PR TITLE
fix whitespace / help message & add contrib/runit.run

### DIFF
--- a/6tunnel.c
+++ b/6tunnel.c
@@ -1,21 +1,21 @@
 /*
  *  6tunnel v0.12
  *  (C) Copyright 2000-2005,2013,2016 by Wojtek Kaniewski <wojtekka@toxygen.net>
- *  
+ *
  *  Contributions by:
  *  - Dariusz Jackowski <ascent@linux.pl>
  *  - Ramunas Lukosevicius <lukoramu@parok.lt>
  *  - Roland Stigge <stigge@antcom.de>
- *  
+ *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License Version 2 as
  *  published by the Free Software Foundation.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
@@ -120,7 +120,7 @@ char *xntop(const struct sockaddr *sa)
 		}
 	}
 	else if (sa->sa_family == AF_INET6)
-	{		
+	{
 		struct sockaddr_in6 *sin6 = (struct sockaddr_in6*) sa;
 		tmp = xmalloc(INET6_ADDRSTRLEN);
 
@@ -130,7 +130,7 @@ char *xntop(const struct sockaddr *sa)
 			tmp = NULL;
 		}
 	}
-	
+
 	return tmp;
 }
 
@@ -161,7 +161,7 @@ struct addrinfo *resolve_host(const char *name, int port, int hint)
 void print_hexdump(const char *buf, int len)
 {
 	int i, j;
-  
+
 	for (i = 0; i < ((len / 16) + ((len % 16) ? 1 : 0)); i++) {
 		printf("%.4x: ", i * 16);
 
@@ -173,9 +173,9 @@ void print_hexdump(const char *buf, int len)
 			if (j == 7)
 				printf(" ");
 		}
-		
+
 		printf(" ");
-		
+
 		for (j = 0; j < 16; j++) {
 			if (i * 16 + j < len) {
 				char ch = buf[i * 16 + j];
@@ -239,7 +239,7 @@ void make_tunnel(int rsock, const char *client_addr)
 		}
 
 		buf[i] = 0;
-		
+
 		if (i > 0 && buf[i - 1] == '\r')
 			buf[i - 1] = 0;
 
@@ -252,7 +252,7 @@ void make_tunnel(int rsock, const char *client_addr)
 			if (write(rsock, tmp, strlen(tmp)) != strlen(tmp)) {
 				// Do nothing. We're failing anyway.
 			}
-				
+
 			goto cleanup;
 		}
 
@@ -264,10 +264,10 @@ void make_tunnel(int rsock, const char *client_addr)
 			if (write(rsock, tmp, strlen(tmp)) != strlen(tmp)) {
 				// Do nothing. We're failing anyway.
 			}
-			
+
 			goto cleanup;
 		}
-		
+
 		debug("<%d> irc proxy auth succeeded\n", rsock);
 	}
 
@@ -288,7 +288,7 @@ void make_tunnel(int rsock, const char *client_addr)
 
 	for (ai_ptr = connect_ai; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next) {
 		sock = socket(ai_ptr->ai_family, ai_ptr->ai_socktype, 0);
-	
+
 		if (sock == -1) {
 			if (ai_ptr->ai_next != NULL)
 				continue;
@@ -299,7 +299,7 @@ void make_tunnel(int rsock, const char *client_addr)
 		if (source != NULL)
 		{
 			bind_ai = resolve_host(source, 0, source_hint);
-	
+
 			if (bind_ai == NULL) {
 				debug("<%d> unable to resolve source host (%s)\n", rsock, (source != NULL) ? source : "default");
 				goto cleanup;
@@ -326,7 +326,7 @@ void make_tunnel(int rsock, const char *client_addr)
 			debug("<%d> connection failed (%s,%d)\n", rsock, remote_host, remote_port);
 			goto cleanup;
 		}
-		
+
 		close(sock);
 		sock = -1;
 	}
@@ -355,7 +355,7 @@ void make_tunnel(int rsock, const char *client_addr)
 			FD_SET(rsock, &wds);
 		if (inbuf && inlen)
 			FD_SET(sock, &wds);
-    
+
 		ret = select((sock > rsock) ? (sock + 1) : (rsock + 1), &rds, &wds, NULL, NULL);
 
 		if (FD_ISSET(rsock, &wds)) {
@@ -398,12 +398,12 @@ void make_tunnel(int rsock, const char *client_addr)
 				printf("<%d> recvfrom %s,%d\n", rsock, remote_host, remote_port);
 				print_hexdump(buf, ret);
 			}
-			
+
 			sent = write(rsock, buf, ret);
 
 			if (sent < 1)
 				goto cleanup;
-			
+
 			if (sent < ret) {
 				outbuf = xrealloc(outbuf, outlen + ret - sent);
 				memcpy(outbuf + outlen, buf + sent, ret - sent);
@@ -449,17 +449,18 @@ cleanup:
 void usage(const char *arg0)
 {
 	fprintf(stderr,
-			
+
 "usage: %s [-146dvh] [-s sourcehost] [-l localhost] [-i pass]\n"
 "           [-I pass] [-L limit] [-A filename] [-p pidfile]\n"
 "           [-m mapfile] localport remotehost [remoteport]\n"
-"\n"	   
+"\n"
 "  -1  allow only single connection and quit\n"
 "  -4  connect to IPv4 endpoints (default: connect to IPv6)\n"
 "  -6  bind to IPv6 address (default: bind to IPv4)\n"
 "  -d  don't detach\n"
 "  -f  force tunneling (even if remotehost isn't resolvable)\n"
 "  -h  print hex dump of packets\n"
+"  -u  change UID and GID after bind()\n"
 "  -i  act like irc proxy and ask for password\n"
 "  -I  send specified password to the irc server\n"
 "  -l  bind to specified address\n"
@@ -474,7 +475,7 @@ void usage(const char *arg0)
 void clear_argv(char *argv)
 {
 	int x;
-  
+
 	for (x = 0; x < strlen(argv); x++)
 		argv[x] = 'x';
 
@@ -484,12 +485,12 @@ void clear_argv(char *argv)
 void source_map_destroy(void)
 {
 	source_map_t *m;
-	
+
 	debug("source_map_destroy()\n");
-	
+
 	for (m = source_map; m != NULL; ) {
 		source_map_t *n;
-		
+
 		free(m->ipv4);
 		free(m->ipv6);
 		n = m;
@@ -513,7 +514,7 @@ void map_read(void)
 		debug("unable to read map file, ignoring\n");
 		return;
 	}
-	
+
 	while (fgets(buf, sizeof(buf), f) != NULL) {
 		char *p, *ipv4, *ipv6;
 		source_map_t *m;
@@ -545,14 +546,14 @@ void map_read(void)
 		*p = 0;
 
 		debug("[%s] mapped to [%s]\n", ipv4, ipv6);
-		
+
 		m = (source_map_t*) xmalloc(sizeof(source_map_t));
 		m->ipv4 = xstrdup(ipv4);
 		m->ipv6 = xstrdup(ipv6);
 		m->next = source_map;
 		source_map = m;
 	}
-	
+
 	fclose(f);
 }
 
@@ -596,7 +597,7 @@ int main(int argc, char **argv)
 	struct passwd *pw = NULL;
 	char *tmp;
 	int source_hint;
-	
+
 	while ((optc = getopt(argc, argv, "1dv46fHs:l:I:i:hu:m:L:A:p:")) != -1) {
 		switch (optc) {
 			case '1':
@@ -660,7 +661,7 @@ int main(int argc, char **argv)
 
 	if (verbose)
 		detach = 0;
-	
+
 	if (detach)
 		verbose = 0;
 
@@ -677,17 +678,17 @@ int main(int argc, char **argv)
 			exit(1);
 		}
 	}
-  
-	if (source_map_file != NULL) 
+
+	if (source_map_file != NULL)
 		map_read();
-  
+
 	local_port = atoi(argv[optind++]);
 	remote_host = argv[optind++];
 	remote_port = (argc == optind) ? local_port : atoi(argv[optind]);
 
 	/* Check if destination and source hosts are resolvable. If it's expected to be
 	 * available later, -f can be used. */
- 
+
 	debug("resolving %s\n", remote_host);
 
 	ai = resolve_host(remote_host, remote_port, remote_hint[0]);
@@ -751,7 +752,7 @@ int main(int argc, char **argv)
 	free(tmp);
 
 	/* Now that we know that hosts are resolvable, dump some debugging information. */
- 
+
 	debug("local: %s,%d; ", (local_host != NULL) ? local_host : "default", local_port);
 	debug("remote: %s,%d; ", remote_host, remote_port);
 
@@ -773,14 +774,14 @@ int main(int argc, char **argv)
 		perror("setsockopt");
 		exit(1);
 	}
-  
+
 	for (ai_ptr = ai; ai_ptr != NULL; ai_ptr = ai_ptr->ai_next) {
 		if (bind(listen_fd, ai_ptr->ai_addr, ai_ptr->ai_addrlen) == -1 && ai_ptr->ai_next == NULL) {
 			perror("bind");
 			exit(1);
 		}
-	}    
-  
+	}
+
 	if (listen(listen_fd, 100) == -1) {
 		perror("listen");
 		exit(1);
@@ -795,12 +796,12 @@ int main(int argc, char **argv)
 		int i, ret;
 
 		signal(SIGHUP, sighup);
-		
+
 		for (i = 0; i < 3; i++)
 			close(i);
 
 		ret = fork();
-		
+
 		if (ret == -1) {
 			perror("fork");
 			exit(1);
@@ -837,8 +838,8 @@ int main(int argc, char **argv)
 	signal(SIGTERM, sigterm);
 	signal(SIGINT, sigterm);
 	signal(SIGHUP, sighup);
-    
-	for (;;) {  
+
+	for (;;) {
 		int ret;
 		fd_set rds;
 		int client_fd;
@@ -859,7 +860,7 @@ int main(int argc, char **argv)
 		}
 
 		client_fd = accept(listen_fd, &sa, &sa_len);
-		
+
 		if (client_fd == -1) {
 			perror("accept");
 			break;
@@ -878,14 +879,14 @@ int main(int argc, char **argv)
 			close(client_fd);
 			continue;
 		}
-		
+
 		if (conn_limit) {
 			conn_count++;
 			debug(" (no. %d)", conn_count);
 		}
-		
+
 		fflush(stdout);
-    
+
 		if ((ret = fork()) == -1) {
 			debug(" -- fork() failed.\n");
 			shutdown(client_fd, 2);
@@ -893,7 +894,7 @@ int main(int argc, char **argv)
 			free(client_addr);
 			continue;
 		}
-    
+
 		if (!ret) {
 			signal(SIGHUP, SIG_IGN);
 			close(listen_fd);
@@ -902,11 +903,11 @@ int main(int argc, char **argv)
 			free(client_addr);
 			debug("<%d> connection closed\n", client_fd);
 			exit(0);
-		} 
+		}
 
 		close(client_fd);
 		free(client_addr);
-    
+
 		if (single_connection) {
 			shutdown(listen_fd, 2);
 			close(listen_fd);
@@ -916,8 +917,6 @@ int main(int argc, char **argv)
 	}
 
 	close(listen_fd);
-  
+
 	exit(1);
 }
-
-

--- a/contrib/runit.run
+++ b/contrib/runit.run
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# example run script for service supervision with runit
+# http://smarden.org/runit/
+#
+# redirect ipv4 port 80 to internal ipv6 port 80 & drop privileges
+#
+exec 2>&1
+exec 6tunnel -u nobody -d -p /run/80.pid 80 a:dead:beef:1 80
+
+


### PR DESCRIPTION
adds example run script for service supervision with [`runit`](http://smarden.org/runit/)
whitespace in `6tunnel.c` removed
adds -u option to help message